### PR TITLE
Show raw invalid hash as a separate field

### DIFF
--- a/txfeebatch.py
+++ b/txfeebatch.py
@@ -163,10 +163,11 @@ def main() -> int:
 
     for raw in hashes_raw:
         tx_hash = normalize_hash(raw)
-        if tx_hash is None:
-            print(f"{err_emoji}invalid-hash | {raw}")
+           if tx_hash is None:
+            print(f"{err_emoji}invalid-hash | raw={raw}")
             any_error = True
             continue
+
 
         try:
             tx = w3.eth.get_transaction(tx_hash)


### PR DESCRIPTION
Make invalid-hash output more machine-friendly