### PR TITLE
Abort when chainIds differ between RPCs

### DIFF
--- a/tx_fee_compare.py
+++ b/tx_fee_compare.py
@@ -264,6 +264,13 @@ def main() -> int:
 
     v1 = build_view(w3_1, args.rpc1, tx_hash)
     v2 = build_view(w3_2, args.rpc2, tx_hash) if w3_2 is not None else None
+    if v2 is not None and v1.chain_id is not None and v2.chain_id is not None:
+        if v1.chain_id != v2.chain_id:
+            print(
+                f"{err_icon} chainId mismatch between primary ({v1.chain_id}) and secondary ({v2.chain_id}).",
+                file=sys.stderr,
+            )
+            return 1
 
     elapsed = round(time.monotonic() - start, 3)
 


### PR DESCRIPTION
Comparing a tx on two different networks is meaningless; fail loudly