### PR TITLE
Treat pending as a clearly labeled status in human output

### DIFF
--- a/tx_fee_compare.py
+++ b/tx_fee_compare.py
@@ -285,10 +285,15 @@ def main() -> int:
         print(f"Secondary RPC: {args.rpc2}")
     print()
 
-    def print_view(label: str, v: TxView) -> None:
+     def print_view(label: str, v: TxView) -> None:
         if not v.ok:
-            print(f"{label}: {err_icon} {v.error}")
+            status = v.error or "unknown-error"
+            if status == "pending":
+                print(f"{label}: {warn_icon} pending (no receipt yet)")
+            else:
+                print(f"{label}: {err_icon} {status}")
             return
+
         print(f"{label}: {ok_icon} chainId={v.chain_id} block={v.block_number} status={v.status}")
         print(
             f"  gasUsed={v.gas_used}  gasPrice={fmt_gwei(v.gas_price_wei)} Gwei  "


### PR DESCRIPTION
ight now “pending” is only in the error field; label it clearly