### PR TITLE
Fix elapsed-time footer in print_table

### DIFF
--- a/txfeecompare.py
+++ b/txfeecompare.py
@@ -404,10 +404,11 @@ def print_table(results: List[EndpointResult], tx_hash: str, elapsed: float) -> 
     for note in summarize_inconsistencies(results):
         print(note)
 
-       if elapsed < 1:
+      if elapsed < 1:
         print(f"⏱️ Elapsed: {elapsed * 1000:.0f}ms")
     else:
         print(f"⏱️ Elapsed: {elapsed:.2f}s")
+
 
 
 


### PR DESCRIPTION
The final elapsed block is mis-indented and uses elapsed correctly but with broken if.