### PR TITLE
 Fix broken indentation & syntax (script won’t even run now)

### DIFF
--- a/txfeebatch.py
+++ b/txfeebatch.py
@@ -39,7 +39,7 @@ def build_parser() -> argparse.ArgumentParser:
     p = argparse.ArgumentParser(
         description="Batch-check transaction fee soundness for multiple tx hashes."
     )
-        p.add_argument(
+    p.add_argument(
         "--min-confirmations",
         type=int,
         default=0,


### PR DESCRIPTION
build_parser() has a bad indent.