### PR TITLE
Chore: add error handling for missing environment variables

### DIFF
--- a/compare_etherscan_vs_rpc.py
+++ b/compare_etherscan_vs_rpc.py
@@ -52,6 +52,10 @@ def fetch_via_etherscan(tx_hash, chain="mainnet"):
     }
 
 def main():
+    if not RPC_URL:
+    raise RuntimeError("Set RPC_URL environment variable")
+if not ETHERSCAN_API_KEY:
+    raise RuntimeError("Set ETHERSCAN_API_KEY environment variable")
     if len(sys.argv) < 2:
         print("Usage: python compare_etherscan_vs_rpc.py <tx_hash> [chain]")
         sys.exit(1)


### PR DESCRIPTION
## Summary

Currently, if the `RPC_URL` or `ETHERSCAN_API_KEY` environment variables are missing, the script may fail without a clear error. Adding error handling at the start would improve user experience and avoid confusion.

## Changes

- Check if the `RPC_URL` and `ETHERSCAN_API_KEY` environment variables are set at the beginning of the `main()` function.
- Raise a `RuntimeError` with a clear message if any of the required environment variables are missing.

## Rationale

- Improves error handling and user feedback.
- Helps users quickly identify missing environment variables instead of debugging unknown failures.